### PR TITLE
add ranking based search

### DIFF
--- a/pages/api/schemas/index.ts
+++ b/pages/api/schemas/index.ts
@@ -14,7 +14,7 @@ export const schema = gql`
     season: String
     airedStart: String
     description: String
-    score: Int
+    score: Float
     airedEnd: String
     duration: String
     sourceMaterialType: String
@@ -41,6 +41,7 @@ export const schema = gql`
       hitsPerPage: Int
       offset: Int
       limit: Int
+      searchableAttributes: [String!]
     ): SearchResponse!
   }
 

--- a/services/agolia.ts
+++ b/services/agolia.ts
@@ -20,11 +20,13 @@ export class Agolia extends DataSource {
   async searchAnime({
     query,
     page,
+    searchableAttributes,
     hitsPerPage,
     offset,
     limit,
   }: QuerySearchAnimeArgs) {
     const results = await this.index.search(query, {
+      restrictSearchableAttributes: searchableAttributes || undefined,
       hitsPerPage: hitsPerPage || undefined,
       page: page || undefined,
       offset: offset || undefined,


### PR DESCRIPTION


Add searchableAttributes parameter, use this to search by attribute ex: searchableAttributes:["airedDate"] will allow you to only search by that field 

query now defaults to sort by score: send empty string to query and results will be returned automatically in score order﻿




Most of the changes were done on the agolia SaSS
